### PR TITLE
Fix  missing org.phoebus.pv.PVFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,6 @@
       </plugin>
     </plugins>
 
-    <resources>
-      <resource>
-        <directory>${project.basedir}</directory>
-        <includes>
-        <include>site_splash.png</include>
-        </includes>
-      <targetPath>${project.build.directory}</targetPath>
-      </resource>
-    </resources>
   </build>
 
   <modules>

--- a/product-fnal/pom.xml
+++ b/product-fnal/pom.xml
@@ -112,10 +112,12 @@
                   <directory>${docs}/build/html</directory>
                   <filtering>true</filtering>
                 </resource>
-                <!-- copy the welcome html screens -->
-                <resource>
-                  <directory>${project.basedir}/resources</directory>
-                  <filtering>true</filtering>
+               <resource>
+                  <directory>${project.basedir}</directory>
+                  <includes>
+                    <include>site_splash.png</include>
+                  </includes>
+                  <targetPath>${project.build.directory}</targetPath>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
The previous commit (49b332c) incorrectly included `site_splash.png` at the root level, causing the org.phoebus.pv.PVFactory to not be copied into ./classes/META-INF/services/org.phoebus.pv.PVFactory.

This commit resolves the issue by adjusting the pom.xml configuration to ensure the correct placement of `site_splash.png` without interfering with the PVFactory file.


Manual testing:

```
~/phoebus-fnal/product-fnal/target> find . -name  org.phoebus.pv.PVFactory
./classes/META-INF/services/org.phoebus.pv.PVFactory
~/phoebus-fnal/product-fnal/target> find . -name  site_splash.png
./site_splash.png
```