### PR TITLE
restore proper LoopCommand negative inc behavior

### DIFF
--- a/scan-server-fnal/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/scan-server-fnal/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -268,12 +268,16 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
             executeStep(context, device, condition, readback, start + i * step);
             // check if inside the loop, the device was set to a value that ends the loop
             final VType value = device.read();
-            if (reverse)
-                if (((VDouble)value).getValue() < resolvedEnd) // there isn't a tolerance
+            if (step < 0)
+            {
+                if (VTypeHelper.toDouble(value) < loopMin) // there isn't a tolerance
                     break;
+            }
             else
-                if (((VDouble)value).getValue() > resolvedEnd) // there isn't a tolerance
+            {
+                if (VTypeHelper.toDouble(value) > loopMax) // there isn't a tolerance
                     break;
+            }
         }
     }
 

--- a/scan-server-fnal/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
+++ b/scan-server-fnal/src/main/java/org/csstudio/scan/server/command/LoopCommandImpl.java
@@ -268,8 +268,12 @@ public class LoopCommandImpl extends ScanCommandImpl<LoopCommand>
             executeStep(context, device, condition, readback, start + i * step);
             // check if inside the loop, the device was set to a value that ends the loop
             final VType value = device.read();
-            if (((VDouble)value).getValue() > resolvedEnd) // there isn't a tolerance
-                break;
+            if (reverse)
+                if (((VDouble)value).getValue() < resolvedEnd) // there isn't a tolerance
+                    break;
+            else
+                if (((VDouble)value).getValue() > resolvedEnd) // there isn't a tolerance
+                    break;
         }
     }
 


### PR DESCRIPTION
In further testing, I found that my previous change to the LoopCommand broke the negative increment functionality.
This simple fix restores it.